### PR TITLE
fix(package-requires): Can't read whole string

### DIFF
--- a/website2org.el
+++ b/website2org.el
@@ -5,7 +5,7 @@
 ;; Maintainer: René Trappel <rtrappel@gmail.com>
 ;; URL:
 ;; Version: 0.1.1
-;; Package-Requires: emacs "26" (maybe earlier), wget
+;; Package-Requires: ((emacs "26"))
 ;; Keywords: html websites orgmode
 
 ;; This file is not part of GNU Emacs.


### PR DESCRIPTION
Fix `Can't read whole string` error. I got it by trying to install the package with the `:vc` keyword from `use-package`.
I'll also be sending another PR for [package linting](https://github.com/purcell/package-lint) if you ever want to upload this to a repository like MELPA.